### PR TITLE
fix: sync tag filter with URL query parameters

### DIFF
--- a/site/src/pages/notes/index.astro
+++ b/site/src/pages/notes/index.astro
@@ -241,9 +241,18 @@ function formatDate(date: Date): string {
   const urlParams = new URLSearchParams(window.location.search);
   const tagParam = urlParams.get('tag');
   if (tagParam) {
-    const tagBtn = document.querySelector(`.tag-btn[data-tag="${tagParam}"]`) as HTMLElement;
-    if (tagBtn) {
-      tagBtn.click();
+    // Validate against known tags to prevent XSS via querySelector
+    const validTags = Array.from(tagButtons).map(btn => btn.getAttribute('data-tag'));
+    if (validTags.includes(tagParam)) {
+      const tagBtn = document.querySelector(`.tag-btn[data-tag="${tagParam}"]`) as HTMLElement;
+      if (tagBtn) {
+        tagBtn.click();
+      }
+    } else {
+      // Invalid tag - clear the URL parameter
+      const url = new URL(window.location.href);
+      url.searchParams.delete('tag');
+      history.replaceState({}, '', url);
     }
   }
 </script>


### PR DESCRIPTION
## Summary
- Clicking tags on `/notes/` now updates the URL query parameter (`?tag=X`)
- Selecting "all" removes the query parameter
- URL stays in sync with filter state, making it shareable and refresh-safe

## Test plan
- [ ] Navigate to `/notes/`
- [ ] Click a tag (e.g., "technology") and verify URL updates to `?tag=technology`
- [ ] Click "all" and verify `?tag` parameter is removed
- [ ] Refresh page with `?tag=X` and verify filter is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)