### PR TITLE
Remove background from poetry/blockquote elements

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -102,3 +102,10 @@ body {
   transform: scale(1.05);
   transition: transform 0.1s;
 }
+
+/* Remove background from poetry/blockquote elements */
+.prose blockquote,
+.md-block blockquote {
+  background: none;
+  background-color: transparent;
+}

--- a/site/tailwind.config.cjs
+++ b/site/tailwind.config.cjs
@@ -28,9 +28,14 @@ module.exports = {
             "--tw-prose-captions": theme("colors.text-color"),
             "--tw-prose-code": theme("colors.text-color"),
             "--tw-prose-pre-code": theme("colors.text-color"),
-            "--tw-prose-pre-bg": theme("colors.text-color"),
+            "--tw-prose-pre-bg": "transparent",
             "--tw-prose-th-borders": theme("colors.text-color"),
             "--tw-prose-td-borders": theme("colors.text-color"),
+            // Remove background from blockquotes (poetry)
+            "blockquote": {
+              backgroundColor: "transparent",
+              background: "none",
+            },
             "--tw-prose-invert-body": theme("colors.pink[200]"),
             "--tw-prose-invert-headings": theme("colors.white"),
             "--tw-prose-invert-lead": theme("colors.pink[300]"),


### PR DESCRIPTION
- Set --tw-prose-pre-bg to transparent in tailwind config
- Added explicit blockquote background removal in typography config
- Added CSS rules to remove background from .prose and .md-block blockquotes